### PR TITLE
Move latents to CPU

### DIFF
--- a/nn_upscale.py
+++ b/nn_upscale.py
@@ -65,5 +65,7 @@ class NNLatentUpscale:
         if self.dtype != torch.float32:
             latent_out = latent_out.to(dtype=torch.float32)
 
+        latent_out = latent_out.to(device="cpu")
+
         self.model.to(device=model_management.vae_offload_device())
         return ({"samples": latent_out},)


### PR DESCRIPTION
Ensure latent is on CPU device and compatible with other latent operations.

Won't matter for ksamplers as they are going to force latent onto the diffusion device set. But for stuff like "latent blend" and stuff, where latents are expects to be on CPU, it is a issue. 